### PR TITLE
Collision fix

### DIFF
--- a/PhysicsEditor-Cocos2D-V3/Classes/GCCShapeCache.m
+++ b/PhysicsEditor-Cocos2D-V3/Classes/GCCShapeCache.m
@@ -196,8 +196,14 @@ typedef enum
     [shape setFriction:fixture->friction];
     [shape setSurfaceVelocity:fixture->surfaceVelocity];
     [shape setSensor:fixture->isSensor];
-    [shape setCollisionCategories:fixture->collisionCategories];
-    [shape setCollisionMask:fixture->collisionMask];
+    if (fixture->collisionCategories != nil && [fixture->collisionCategories count] > 0)
+    {
+        [shape setCollisionCategories:fixture->collisionCategories];
+    }
+    if (fixture->collisionMask != nil && [fixture->collisionMask count] > 0)
+    {
+        [shape setCollisionMask:fixture->collisionMask];
+    }
     if (fixture->collisionGroup != nil)
     {
         [shape setCollisionGroup:fixture->collisionGroup];


### PR DESCRIPTION
If collision categories was set to empty array, collisionType and
collisionGroup thing wasn’t working resulting in non-working collisions.
