### PR TITLE
Add a parameter for specifying inner padding

### DIFF
--- a/Exporters/cocos2d-v3/cocos2d-v3.plist
+++ b/Exporters/cocos2d-v3/cocos2d-v3.plist
@@ -9,10 +9,12 @@
         </dict>
         <key>scale_factor</key>
         <real>{{global.scale_factor}}</real>
+        <key>inner_padding</key>
+        <real>{{global.inner_padding}}</real>
         <key>category_names</key>
         <array>{% for bit in global.collision_bitfield %}
             <string>{{bit}}</string>{% endfor %}
-        </array>         
+        </array>
         <key>bodies</key>
         <dict>
 {% for body in bodies %}
@@ -55,9 +57,9 @@
                         <string>{{fixture.type}}</string>
                         <key>circle</key>
                         <dict>
-                            <key>radius</key> 
+                            <key>radius</key>
                             <real>{{fixture.radius|floatformat:3}}</real>
-                            <key>position</key> 
+                            <key>position</key>
                             <string>{ {{fixture.center.x|floatformat:3}},{{fixture.center.y|floatformat:3}} }</string>
                         </dict>
                         {% else %}
@@ -66,7 +68,7 @@
                         <string>POLYLINE</string>
                         <key>polygons</key>
                         <array>
-                            <array>{% for point in fixture.hull %}   
+                            <array>{% for point in fixture.hull %}
                                 <string>{ {{point.x|floatformat:5}},{{point.y|floatformat:5}} }</string>{% endfor %}
                             </array>
                         </array>
@@ -75,7 +77,7 @@
                         <string>{{fixture.type}}</string>
                         <key>polygons</key>
                         <array>{% for polygon in fixture.polygons %}
-                            <array>{% for point in polygon %}   
+                            <array>{% for point in polygon %}
                                 <string>{ {{point.x|floatformat:5}},{{point.y|floatformat:5}} }</string>{% endfor %}
                             </array>{% endfor %}
                         </array>

--- a/Exporters/cocos2d-v3/exporter.xml
+++ b/Exporters/cocos2d-v3/exporter.xml
@@ -26,8 +26,15 @@
             <type>float</type>
             <default>1.0</default>
         </parameter>
+        <parameter>
+            <name>inner_padding</name>
+            <displayName>Inner Padding</displayName>
+            <description>The inner padding used on the sprite sheet</description>
+            <type>float</type>
+            <default>0.0</default>
+        </parameter>
     </global>
-    
+
     <!-- body settings ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
     <body>
         <parameter>

--- a/PhysicsEditor-Cocos2D-V3/Classes/GCCShapeCache.m
+++ b/PhysicsEditor-Cocos2D-V3/Classes/GCCShapeCache.m
@@ -159,6 +159,7 @@ typedef enum
 {
     NSArray *categoryNames;
     CGFloat scaleFactor;
+    CGFloat innerPadding;
 }
 
 + (GCCShapeCache *)sharedShapeCache
@@ -307,6 +308,7 @@ typedef enum
     
     categoryNames = [dictionary objectForKey:@"category_names"];
     scaleFactor = [[dictionary objectForKey:@"scale_factor"] floatValue];
+    innerPadding = [[dictionary objectForKey:@"inner_padding"] floatValue];
     
     NSDictionary *bodyDict = [dictionary objectForKey:@"bodies"];
 
@@ -396,8 +398,8 @@ typedef enum
                     for(NSString *pointString in polygonArray)
                     {
                         CGPoint offset = CGPointFromString_(pointString);
-                        vertices[vindex].x = offset.x / scaleFactor;
-                        vertices[vindex].y = offset.y / scaleFactor;
+                        vertices[vindex].x = (offset.x + innerPadding) / scaleFactor;
+                        vertices[vindex].y = (offset.y + innerPadding) / scaleFactor;
                         vindex++;
                     }
 
@@ -411,8 +413,8 @@ typedef enum
 
                 fd->radius = [[circleData objectForKey:@"radius"] floatValue] / scaleFactor;
                 fd->center = CGPointFromString_([circleData objectForKey:@"position"]);
-                fd->center.x /= scaleFactor;
-                fd->center.y /= scaleFactor;
+                fd->center.x = (fd->center.x + innerPadding) / scaleFactor;
+                fd->center.y = (fd->center.y + innerPadding) / scaleFactor;
             }
             else
             {


### PR DESCRIPTION
When using inner padding on your sprite sheet the shape coordinates end up wrong since they are based on the image without the padding. I have added a parameter for specifying the inner padding used on the sprite sheet. Just use the same value that you have specified in TexturePacker and your shapes should be placed correctly.

![inner_padding](https://cloud.githubusercontent.com/assets/554766/5776108/47278a50-9d83-11e4-8de4-5d23518280d1.png)
